### PR TITLE
New evaluation routine

### DIFF
--- a/benchmark/evaluation.jl
+++ b/benchmark/evaluation.jl
@@ -1,0 +1,23 @@
+using BenchmarkTools
+import DynamicPolynomials: @polyvar
+using FixedPolynomials
+
+@polyvar x y
+f1 = x + y + 1
+f2 = (x + 1)^4 + y
+f3 = 50x^3+83x^2*y+24x*y^2+y^3+392x^2+414x*y+50y^2-28x+59y-100
+f4 = x+x^2+y+x*y^3+x^4*y^2+3x^3*y+10*x*y+10x^2*y+10x*y^2+15x^2*y^2+10x^3*y^2
+
+function make(f)
+    p = Polynomial{Float64}(f)
+    w = rand(2)
+    result = @benchmark evaluate($p, $w)
+    println(STDOUT, f)
+    show(STDOUT, MIME"text/plain"(), result)
+    println("\n")
+end
+
+make(f1)
+make(f2)
+make(f3)
+make(f4)

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -34,6 +34,13 @@ struct Polynomial{T<:Number}
     homogenized::Bool
 
     # this are only internal data structures to avoid allocations
+    # Let M the exponents matrix. Then we can associate a matrix M' in which each
+    # row of m was sorted separetly in ascending order.
+    # `_phi` is the  map from M' to M s.t. M[i,j] == M'[i, _phi[i,j]]
+    # For each row of M' we can only store the difference to the previous value.
+    # This is `_sorteddiff`.
+    # To evaluate a polynomial we then use '_phi' and '_sorteddiff' to compute the matrix
+    # `x.^M` and store the result in `_values`.
     _phi::Matrix{Int}
     _sorteddiff::Matrix{Int}
     _values::Matrix{T}


### PR DESCRIPTION
This new evaluation algorithm increases the memory footprint of a `FixedPolynomial` but for this we get performance increases with a factor of up to **7** (and probably even more for polynomials with higher degrees).

Here are the detailed benchmark results from the committed `benchmark/evaluation.jl`:
master
```
x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     84.496 ns (0.00% GC)
  median time:      86.308 ns (0.00% GC)
  mean time:        91.803 ns (0.00% GC)
  maximum time:     244.586 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     962

x^4 + 4x^3 + 6x^2 + 4x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     174.762 ns (0.00% GC)
  median time:      181.137 ns (0.00% GC)
  mean time:        191.230 ns (0.00% GC)
  maximum time:     472.054 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     723

50x^3 + 83x^2y + 24xy^2 + y^3 + 392x^2 + 414xy + 50y^2 - 28x + 59y - 100
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     350.547 ns (0.00% GC)
  median time:      363.752 ns (0.00% GC)
  mean time:        386.236 ns (0.00% GC)
  maximum time:     11.714 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     214

x^4y^2 + 10x^3y^2 + 3x^3y + 15x^2y^2 + xy^3 + 10x^2y + 10xy^2 + x^2 + 10xy + x + y
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     474.281 ns (0.00% GC)
  median time:      491.551 ns (0.00% GC)
  mean time:        530.601 ns (0.00% GC)
  maximum time:     1.745 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     196
```

this branch
```
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     30.199 ns (0.00% GC)
  median time:      30.317 ns (0.00% GC)
  mean time:        33.423 ns (0.00% GC)
  maximum time:     822.494 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     994

x^4 + 4x^3 + 6x^2 + 4x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     41.132 ns (0.00% GC)
  median time:      44.613 ns (0.00% GC)
  mean time:        47.831 ns (0.00% GC)
  maximum time:     580.027 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     990

50x^3 + 83x^2y + 24xy^2 + y^3 + 392x^2 + 414xy + 50y^2 - 28x + 59y - 100
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     57.427 ns (0.00% GC)
  median time:      57.682 ns (0.00% GC)
  mean time:        63.204 ns (0.00% GC)
  maximum time:     348.563 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     983

x^4y^2 + 10x^3y^2 + 3x^3y + 15x^2y^2 + xy^3 + 10x^2y + 10xy^2 + x^2 + 10xy + x + y
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     61.178 ns (0.00% GC)
  median time:      65.876 ns (0.00% GC)
  mean time:        83.605 ns (0.00% GC)
  maximum time:     10.336 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     981
```