### PR TITLE
Further evaluation improvements

### DIFF
--- a/src/poly.jl
+++ b/src/poly.jl
@@ -200,10 +200,13 @@ function evaluate(p::Polynomial{S}, x::AbstractVector{T}) where {S<:Number, T<:N
         @inbounds values[i,1] = x[i]^sorteddiff[i,1]
     end
 
-    for i=1:m, k=2:n
-        @inbounds l = sorteddiff[i,k]
-        @inbounds v = values[i,k - 1]
-        @inbounds values[i,k] = l == 0 ? v : (l == 1 ? v * x[i] : v * x[i]^sorteddiff[i,k])
+    for i=1:m
+        @inbounds v = values[i, 1]
+        for k=2:n
+            @inbounds l = sorteddiff[i,k]
+            @inbounds v = l == 0 ? v : (l == 1 ? v * x[i] : v * x[i]^l)
+            @inbounds values[i,k] = v
+        end
     end
 
     res = 0.0
@@ -211,7 +214,7 @@ function evaluate(p::Polynomial{S}, x::AbstractVector{T}) where {S<:Number, T<:N
     for k = 1:n
         @inbounds term = c[k]
         for i = 1:m
-            @inbounds term *= p._values[i, phi[i,k]]
+            @inbounds term *= values[i, phi[i,k]]
         end
         res += term
     end


### PR DESCRIPTION
This further improves #1 and yields an improvement of ca. 10% (mainly through less lookups)

```
x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     29.817 ns (0.00% GC)
  median time:      29.993 ns (0.00% GC)
  mean time:        33.115 ns (0.00% GC)
  maximum time:     202.798 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995

x^4 + 4x^3 + 6x^2 + 4x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     40.130 ns (0.00% GC)
  median time:      40.258 ns (0.00% GC)
  mean time:        43.975 ns (0.00% GC)
  maximum time:     144.565 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     991

50x^3 + 83x^2y + 24xy^2 + y^3 + 392x^2 + 414xy + 50y^2 - 28x + 59y - 100
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     57.266 ns (0.00% GC)
  median time:      57.396 ns (0.00% GC)
  mean time:        63.794 ns (0.00% GC)
  maximum time:     314.508 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     983

x^4y^2 + 10x^3y^2 + 3x^3y + 15x^2y^2 + xy^3 + 10x^2y + 10xy^2 + x^2 + 10xy + x + y
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     59.547 ns (0.00% GC)
  median time:      60.038 ns (0.00% GC)
  mean time:        66.877 ns (0.00% GC)
  maximum time:     1.567 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     982
```