### PR TITLE
Further improvements

### DIFF
--- a/benchmark/evaluation.jl
+++ b/benchmark/evaluation.jl
@@ -1,6 +1,6 @@
 using BenchmarkTools
-import DynamicPolynomials: @polyvar
 using FixedPolynomials
+import DynamicPolynomials: @polyvar
 
 @polyvar x y
 f1 = x + y + 1
@@ -8,16 +8,18 @@ f2 = (x + 1)^4 + y
 f3 = 50x^3+83x^2*y+24x*y^2+y^3+392x^2+414x*y+50y^2-28x+59y-100
 f4 = x+x^2+y+x*y^3+x^4*y^2+3x^3*y+10*x*y+10x^2*y+10x*y^2+15x^2*y^2+10x^3*y^2
 
-function make(f)
+w = rand(2)
+
+function make(f, w)
     p = Polynomial{Float64}(f)
-    w = rand(2)
     result = @benchmark evaluate($p, $w)
     println(STDOUT, f)
     show(STDOUT, MIME"text/plain"(), result)
     println("\n")
 end
 
-make(f1)
-make(f2)
-make(f3)
-make(f4)
+println("FixedPolynomials", "\n")
+make(f1, w)
+make(f2, w)
+make(f3, w)
+make(f4, w)

--- a/src/poly.jl
+++ b/src/poly.jl
@@ -196,12 +196,10 @@ function evaluate(p::Polynomial{S}, x::AbstractVector{T}) where {S<:Number, T<:N
     sorteddiff = p._sorteddiff
     phi = p._phi
 
-    for i = 1:m
-        @inbounds values[i,1] = x[i]^sorteddiff[i,1]
-    end
-
     for i=1:m
-        @inbounds v = values[i, 1]
+        @inbounds l = sorteddiff[i,1]
+        @inbounds v = l == 0 ? one(T) : (l == 1 ? x[i] : x[i]^l)
+        @inbounds values[i, 1] = v
         for k=2:n
             @inbounds l = sorteddiff[i,k]
             @inbounds v = l == 0 ? v : (l == 1 ? v * x[i] : v * x[i]^l)
@@ -220,6 +218,7 @@ function evaluate(p::Polynomial{S}, x::AbstractVector{T}) where {S<:Number, T<:N
     end
     res
 end
+
 (p::Polynomial)(x) = evaluate(p, x)
 
 """


### PR DESCRIPTION
There was an unnecessary additional for loop. After I removed it the performance improved even further. I think the code is now nearly optimal.

```
x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     23.995 ns (0.00% GC)
  median time:      24.200 ns (0.00% GC)
  mean time:        26.700 ns (0.00% GC)
  maximum time:     614.453 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     996

x^4 + 4x^3 + 6x^2 + 4x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     34.365 ns (0.00% GC)
  median time:      36.947 ns (0.00% GC)
  mean time:        55.722 ns (0.00% GC)
  maximum time:     24.551 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     992

50x^3 + 83x^2y + 24xy^2 + y^3 + 392x^2 + 414xy + 50y^2 - 28x + 59y - 100
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     45.447 ns (0.00% GC)
  median time:      45.685 ns (0.00% GC)
  mean time:        50.081 ns (0.00% GC)
  maximum time:     238.315 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     989

x^4y^2 + 10x^3y^2 + 3x^3y + 15x^2y^2 + xy^3 + 10x^2y + 10xy^2 + x^2 + 10xy + x + y
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     49.255 ns (0.00% GC)
  median time:      49.745 ns (0.00% GC)
  mean time:        54.466 ns (0.00% GC)
  maximum time:     659.012 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     987
```