### PR TITLE
PolynomialEvaluationArrays

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,8 @@ makedocs(
     sitename = "FixedPolynomials.jl",
     pages = [
         "Introduction" => "index.md",
-        "Reference" => "reference.md",
+        "Polynomial" => "reference.md",
+        "PolynomialEvaluationArray" => "polynomialevaluationarray.md"
         ]
 )
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -36,3 +36,11 @@ f(x) # alternatively evaluate(f, x)
 !!! note
     `f` has then the variable ordering as implied by `DynamicPolynomials.variables(x^2+y^3*z-2x*y)`, i.e.
     `f([1.0, 2.0, 3.0])` will evaluate `f` with `x=1`, `y=2` and `z=3`.
+
+
+## Safety notes
+
+!!! warning
+    For the evaluation multivariate variant of [Horner's method](https://en.wikipedia.org/wiki/Horner%27s_method)
+    is used. Due to that for polynomials with terms of degree over 43 we cannot guarantee
+    an error of less than 1 [ULP](https://en.wikipedia.org/wiki/Unit_in_the_last_place).

--- a/docs/src/polynomialevaluationarray.md
+++ b/docs/src/polynomialevaluationarray.md
@@ -1,0 +1,6 @@
+```@docs
+PolynomialEvaluationArray
+evaluate!
+precompute!
+unsafe_evaluate
+```

--- a/src/FixedPolynomials.jl
+++ b/src/FixedPolynomials.jl
@@ -8,7 +8,9 @@ module FixedPolynomials
     abstract type AbstractPolySystem{T} end
     export AbstractPolySystem
 
+    include("precomputation.jl")
     include("poly.jl")
     include("show.jl")
     include("convert_promote.jl")
+
 end

--- a/src/FixedPolynomials.jl
+++ b/src/FixedPolynomials.jl
@@ -12,5 +12,6 @@ module FixedPolynomials
     include("poly.jl")
     include("show.jl")
     include("convert_promote.jl")
+    include("polynomialarray.jl")
 
 end

--- a/src/polynomialarray.jl
+++ b/src/polynomialarray.jl
@@ -1,0 +1,78 @@
+export PolynomialEvaluationArray, fillvalues!, evaluate!, unsafe_evaluate
+
+"""
+    PolynomialEvaluationArray(polynomials::Array{Polynomial{T}, N})
+
+A structure for the fast evaluation of the given array `polynomials` of polynomials.
+This provides a speedup about the evaluation of the polynomials separetly since it
+shares as much computations as possible over all polynomials.
+"""
+struct PolynomialEvaluationArray{T, N}
+    coefficients::Array{Vector{T}, N}
+    lookuptables::Array{Matrix{Int}, N}
+    diffs::Matrix{Int}
+    values::Matrix{T}
+end
+function PolynomialEvaluationArray(polynomials::Array{Polynomial{T}, N}) where {T,N}
+    nvars = nvariables(first(polynomials))
+    @assert all(p -> nvariables(p) == nvars, polynomials) "All polynomials have to have the same number of variables"
+
+    coeffs = coefficients.(polynomials)
+    exps = exponents.(polynomials)
+
+    ue = unique_exponents(vec(exps))
+    lookuptables = map(exp -> lookuptable(exp, ue), exps)
+    differences = differences!(ue)
+    values = similar(differences, T)
+    PolynomialEvaluationArray{T, N}(coeffs, lookuptables, differences, values)
+end
+
+"""
+    precompute!(pea::PolynomialEvaluationArray{T}, x::AbstractVector{T})
+
+Precompute values for the evaluation of `pea` at `x`.
+"""
+@inline function precompute!(pea::PolynomialEvaluationArray{T}, x::AbstractVector{T}) where T
+    fillvalues!(pea.values, pea.diffs, x)
+end
+
+"""
+    evaluate!(u::AbstractArray{T,N}, pea::PolynomialEvaluationArray{T,N}, x::AbstractVector{T})
+
+Evaluate `pea` at `x` and store the result in `u`. This will result in a call to [precompute!](@ref).
+"""
+function evaluate!(u::AbstractArray{T,N}, pea::PolynomialEvaluationArray{T,N}, x::AbstractVector{T}) where {T,N}
+    precompute!(pea, x)
+    for l in eachindex(pea.lookuptables)
+        lookuptable = pea.lookuptables[l]
+        coefficients = pea.coefficients[l]
+        u[l] = evaluate_lookuptable(lookuptable, pea.values, coefficients)
+    end
+    u
+end
+
+"""
+    unsafe_evaluate(pea::PolynomialEvaluationArray{T,N}, I::Vararg{Int,N})
+
+Evaluate the polynomial with index `I` in `pea` for the value `x` for which the last call to [precompute!](@ref)
+occured.
+
+### Example
+```julia
+F = PolynomialEvaluationArray([f1 f2; f3 f4])
+# assume now we are only interested on the entries f2 and f4
+precompute!(F, x) #this is important!
+unsafe_evaluate(F, 1, 2) == evaluate(f2, x)
+unsafe_evaluate(F, 2, 2) == evaluate(f4, x)
+```
+"""
+function unsafe_evaluate(pea::PolynomialEvaluationArray{T,N}, I::Vararg{Int,N}) where {T,N}
+    lookuptable = pea.lookuptables[I...]
+    coefficients = pea.coefficients[I...]
+    evaluate_lookuptable(lookuptable, pea.values, coefficients)
+end
+function unsafe_evaluate(pea::PolynomialEvaluationArray{T,N}, I::Int) where {T,N}
+    lookuptable = pea.lookuptables[I]
+    coefficients = pea.coefficients[I]
+    evaluate_lookuptable(lookuptable, pea.values, coefficients)
+end

--- a/src/polynomialarray.jl
+++ b/src/polynomialarray.jl
@@ -1,11 +1,11 @@
-export PolynomialEvaluationArray, fillvalues!, evaluate!, unsafe_evaluate
+export PolynomialEvaluationArray, precompute!, evaluate!, unsafe_evaluate
 
 """
     PolynomialEvaluationArray(polynomials::Array{Polynomial{T}, N})
 
 A structure for the fast evaluation of the given array `polynomials` of polynomials.
-This provides a speedup about the evaluation of the polynomials separetly since it
-shares as much computations as possible over all polynomials.
+This provides a speedup about the separete evaluation of the polynomials since
+as much computations as possible are shared over all polynomials of the array.
 """
 struct PolynomialEvaluationArray{T, N}
     coefficients::Array{Vector{T}, N}
@@ -28,33 +28,33 @@ function PolynomialEvaluationArray(polynomials::Array{Polynomial{T}, N}) where {
 end
 
 """
-    precompute!(pea::PolynomialEvaluationArray{T}, x::AbstractVector{T})
+    precompute!(PEA::PolynomialEvaluationArray{T}, x::AbstractVector{T})
 
-Precompute values for the evaluation of `pea` at `x`.
+Precompute values for the evaluation of `PEA` at `x`.
 """
-@inline function precompute!(pea::PolynomialEvaluationArray{T}, x::AbstractVector{T}) where T
-    fillvalues!(pea.values, pea.diffs, x)
+@inline function precompute!(PEA::PolynomialEvaluationArray{T}, x::AbstractVector{T}) where T
+    fillvalues!(PEA.values, PEA.diffs, x)
 end
 
 """
-    evaluate!(u::AbstractArray{T,N}, pea::PolynomialEvaluationArray{T,N}, x::AbstractVector{T})
+    evaluate!(u::AbstractArray{T,N}, PEA::PolynomialEvaluationArray{T,N}, x::AbstractVector{T})
 
-Evaluate `pea` at `x` and store the result in `u`. This will result in a call to [precompute!](@ref).
+Evaluate `PEA` at `x` and store the result in `u`. This will result in a call to [`precompute!`](@ref).
 """
-function evaluate!(u::AbstractArray{T,N}, pea::PolynomialEvaluationArray{T,N}, x::AbstractVector{T}) where {T,N}
-    precompute!(pea, x)
-    for l in eachindex(pea.lookuptables)
-        lookuptable = pea.lookuptables[l]
-        coefficients = pea.coefficients[l]
-        u[l] = evaluate_lookuptable(lookuptable, pea.values, coefficients)
+function evaluate!(u::AbstractArray{T,N}, PEA::PolynomialEvaluationArray{T,N}, x::AbstractVector{T}) where {T,N}
+    precompute!(PEA, x)
+    for l in eachindex(PEA.lookuptables)
+        lookuptable = PEA.lookuptables[l]
+        coefficients = PEA.coefficients[l]
+        u[l] = evaluate_lookuptable(lookuptable, PEA.values, coefficients)
     end
     u
 end
 
 """
-    unsafe_evaluate(pea::PolynomialEvaluationArray{T,N}, I::Vararg{Int,N})
+    unsafe_evaluate(PEA::PolynomialEvaluationArray{T,N}, I::Vararg{Int,N})
 
-Evaluate the polynomial with index `I` in `pea` for the value `x` for which the last call to [precompute!](@ref)
+Evaluate the polynomial with index `I` in `PEA` for the value `x` for which the last call to [`precompute!`](@ref)
 occured.
 
 ### Example
@@ -66,13 +66,13 @@ unsafe_evaluate(F, 1, 2) == evaluate(f2, x)
 unsafe_evaluate(F, 2, 2) == evaluate(f4, x)
 ```
 """
-function unsafe_evaluate(pea::PolynomialEvaluationArray{T,N}, I::Vararg{Int,N}) where {T,N}
-    lookuptable = pea.lookuptables[I...]
-    coefficients = pea.coefficients[I...]
-    evaluate_lookuptable(lookuptable, pea.values, coefficients)
+function unsafe_evaluate(PEA::PolynomialEvaluationArray{T,N}, I::Vararg{Int,N}) where {T,N}
+    lookuptable = PEA.lookuptables[I...]
+    coefficients = PEA.coefficients[I...]
+    evaluate_lookuptable(lookuptable, PEA.values, coefficients)
 end
-function unsafe_evaluate(pea::PolynomialEvaluationArray{T,N}, I::Int) where {T,N}
-    lookuptable = pea.lookuptables[I]
-    coefficients = pea.coefficients[I]
-    evaluate_lookuptable(lookuptable, pea.values, coefficients)
+function unsafe_evaluate(PEA::PolynomialEvaluationArray{T,N}, I::Int) where {T,N}
+    lookuptable = PEA.lookuptables[I]
+    coefficients = PEA.coefficients[I]
+    evaluate_lookuptable(lookuptable, PEA.values, coefficients)
 end

--- a/src/precomputation.jl
+++ b/src/precomputation.jl
@@ -9,11 +9,11 @@ Each row is filled with the unique occuring exponents ``e_1,…,e_{k_i}`` if ``k
 the rest is filled with zeros.
 """
 function unique_exponents(exponents::Vector{Matrix{Int}})
-    m, n = size(first(exponents))
+    m = size(first(exponents), 1)
     sets = map(1:m) do i
         # collect all exponents of the i-th variable
         set = Set{Int}()
-        for k = 1:length(exponents), j = 1:n
+        for k = 1:length(exponents), j = 1:size(exponents[k], 2)
              push!(set, exponents[k][i, j])
         end
         set

--- a/src/precomputation.jl
+++ b/src/precomputation.jl
@@ -1,0 +1,117 @@
+"""
+    unique_exponents(exponents::Vector{Matrix{Int}})
+
+For all exponent matrixes `exponents` find for each variable, i.e. each row, all occuring (unique)
+exponents and sort them in ascending order.
+Let ``k_i`` be the number of occuring exponents for variable ``i``. Then this returns a
+`Matrix` with ``\max_i(k_i)`` columns and number of variables columns.
+Each row is filled with the unique occuring exponents ``e_1,…,e_{k_i}`` if ``k_i < \max_i(k_i)``
+the rest is filled with zeros.
+"""
+function unique_exponents(exponents::Vector{Matrix{Int}})
+    m, n = size(first(exponents))
+    sets = map(1:m) do i
+        # collect all exponents of the i-th variable
+        set = Set{Int}()
+        for k = 1:length(exponents), j = 1:n
+             push!(set, exponents[k][i, j])
+        end
+        set
+    end
+    width = maximum(length.(sets))
+    exps = zeros(Int, m, width)
+    for i=1:m
+        set = sets[i]
+        vals = sort!(collect(set))
+        for j=1:length(vals)
+            exps[i,j] = vals[j]
+        end
+    end
+    exps
+end
+unique_exponents(exponents::Matrix{Int}) = unique_exponents([exponents])
+
+"""
+    lookuptable(exponents::Matrix{Int}, unique_exponents::Matrix{Int})
+
+Compute the lookuptable mapping `exponents` to the correct indices in `unique_exponents`.
+"""
+function lookuptable(exponents::Matrix{Int}, unique_exponents::Matrix{Int})
+    m, n = size(exponents)
+    table = similar(exponents)
+    for j=1:n, i=1:m
+        table[i, j] = findfirst(x -> x == exponents[i, j], unique_exponents[i,:])
+    end
+    table
+end
+
+"""
+    differences!(unique_exponents::Matrix{Int})
+
+For each row, subtract the value in column `j` from the value in column `j-1`. If a negative
+value would occur set it to zero instead.
+We assume that `unique_exponents` was computed with [unique_exponents](@ref).
+"""
+function differences!(unique_exponents::Matrix{Int})
+    m, n = size(unique_exponents)
+    if n == 0
+        return unique_exponents
+    end
+
+    for i=1:m
+        lastexp = unique_exponents[i, 1]
+        for j=2:n
+            newlastexp = unique_exponents[i, j]
+            unique_exponents[i, j] = max(newlastexp - lastexp, 0)
+            lastexp = newlastexp
+        end
+    end
+
+    unique_exponents
+end
+
+@inline pow(x::AbstractFloat, k::Integer) = k == 1 ? x : Base.FastMath.pow_fast(x, k)
+@inline pow(x::Complex, k::Integer) = k == 1 ? x : x^k
+
+"""
+    fillvalues!(values::Matrix{T}, diffs::Matrix{Int}, x::AbstractVector{T}) where T
+
+Fill `values` using the `diffs` `Matrix` as computed by [differences!](@ref) and `x`.
+"""
+@inline function fillvalues!(values::Matrix{T}, diffs::Matrix{Int}, x::AbstractVector{T}) where T
+    m, n = size(values)
+    if n == 0
+        return values
+    end
+    for i=1:m
+        @inbounds l = diffs[i,1]
+        @inbounds xi = x[i]
+        @inbounds v = l == 0 ? one(T) : pow(x[i], l)
+        @inbounds values[i, 1] = v
+        for k=2:n
+            @inbounds l = diffs[i,k]
+            @inbounds v = l == 0 ? v : v * pow(x[i], l)
+            @inbounds values[i,k] = v
+        end
+    end
+    values
+end
+
+"""
+    evaluate_lookuptable(table::Matrix{Int}, values::Matrix{T}, coefficients::Vector{T})
+
+Evalute a polynomial with the given lookuptable `table`, precomputed `values` (as computed
+by [fillvalues!](@ref)) and coefficients `coefficients`.
+"""
+@inline function evaluate_lookuptable(table::Matrix{Int}, values::Matrix{T}, coefficients::Vector{T}) where T
+    res = zero(T)
+    m, n = size(table)
+    for k = 1:n
+        @inbounds term = coefficients[k]
+        for i = 1:m
+            @inbounds term *= values[i, table[i,k]]
+        end
+        res += term
+    end
+    res
+end

--- a/test/poly_test.jl
+++ b/test/poly_test.jl
@@ -76,12 +76,16 @@
     @test weylnorm([f, f]) == √weyldot([f, f], [f, f])
 
 
-    # Due to bug during evaluation of "empty" polynomials
+
     Impl.@polyvar x y z
+
+    @test evaluate(Polynomial{Float64}(x^3+x), [2.0]) ≈ 2.0^3 + 2.0
+
     f = x + y + 2z
     g = x + z
     h = y + z
 
+    # Due to bug during evaluation of "empty" polynomials
     F = convert(Vector{Polynomial{Float64}}, [f, g, h])
 
     J = [differentiate(f, i) for f in F, i=1:nvariables.(F[1])]

--- a/test/polynomialarray_test.jl
+++ b/test/polynomialarray_test.jl
@@ -1,0 +1,29 @@
+@testset "PolynomialEvaluationArray" begin
+    Impl.@polyvar x y
+
+    f = Polynomial{Complex128}(x^2*y+4y^3+x+1)
+    g = Polynomial{Complex128}(x+y+x^5-2x)
+
+    F = PolynomialEvaluationArray([f g; g f])
+
+    u = zeros(Complex128, 2, 2)
+    w = rand(Complex128, 2)
+
+    evaluate!(u, F, w)
+    @test u[1, 1] ≈ evaluate(f, w)
+    @test u[2, 2] ≈ evaluate(f, w)
+    @test u[2, 1] ≈ evaluate(g, w)
+    @test u[1, 2] ≈ evaluate(g, w)
+
+    w = rand(Complex128, 2)
+    fillvalues!(F, w)
+    @test unsafe_evaluate(F, 2, 2) ≈ evaluate(f, w)
+    @test unsafe_evaluate(F, 1, 2) ≈ evaluate(g, w)
+    @test unsafe_evaluate(F, 3) ≈ evaluate(g, w)
+
+    G = PolynomialEvaluationArray([f g])
+    w = rand(Complex128, 2)
+    fillvalues!(G, w)
+    @test unsafe_evaluate(G, 1) ≈ evaluate(f, w)
+    @test unsafe_evaluate(G, 2) ≈ evaluate(g, w)
+end

--- a/test/polynomialarray_test.jl
+++ b/test/polynomialarray_test.jl
@@ -16,14 +16,14 @@
     @test u[1, 2] ≈ evaluate(g, w)
 
     w = rand(Complex128, 2)
-    fillvalues!(F, w)
+    precompute!(F, w)
     @test unsafe_evaluate(F, 2, 2) ≈ evaluate(f, w)
     @test unsafe_evaluate(F, 1, 2) ≈ evaluate(g, w)
     @test unsafe_evaluate(F, 3) ≈ evaluate(g, w)
 
     G = PolynomialEvaluationArray([f g])
     w = rand(Complex128, 2)
-    fillvalues!(G, w)
+    precompute!(G, w)
     @test unsafe_evaluate(G, 1) ≈ evaluate(f, w)
     @test unsafe_evaluate(G, 2) ≈ evaluate(g, w)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using Base.Test
 import DynamicPolynomials
 Impl = DynamicPolynomials
 include("poly_test.jl")
+include("polynomialarray_test.jl")


### PR DESCRIPTION
This introduces a new type `PolynomialEvaluationArray`. The idea is to extend the previous performance improvements to arrays of polynomials.
The implementation is quite straightforward: 
* Find all occurring exponents
* Build up lookup tables for each polynomial
* Use a Horner schema to compute all values `x[i]^k` <-- here are the improvements
* Use the compute values to evaluate the polynomials

To achieve this I also modified the previous implementation for a single polynomial and improved the performance even more:
```
x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     19.861 ns (0.00% GC)
  median time:      20.354 ns (0.00% GC)
  mean time:        25.981 ns (0.00% GC)
  maximum time:     26.923 μs (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     995

x^4 + 4x^3 + 6x^2 + 4x + y + 1
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     29.354 ns (0.00% GC)
  median time:      29.726 ns (0.00% GC)
  mean time:        32.476 ns (0.00% GC)
  maximum time:     213.355 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     994

50x^3 + 83x^2y + 24xy^2 + y^3 + 392x^2 + 414xy + 50y^2 - 28x + 59y - 100
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     35.406 ns (0.00% GC)
  median time:      38.362 ns (0.00% GC)
  mean time:        41.891 ns (0.00% GC)
  maximum time:     665.141 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     992

x^4y^2 + 10x^3y^2 + 3x^3y + 15x^2y^2 + xy^3 + 10x^2y + 10xy^2 + x^2 + 10xy + x + y
BenchmarkTools.Trial: 
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     39.339 ns (0.00% GC)
  median time:      41.795 ns (0.00% GC)
  mean time:        43.575 ns (0.00% GC)
  maximum time:     175.543 ns (0.00% GC)
  --------------
  samples:          10000
```
I think the main reason that the performance is improved is that branch prediction is more successful than previously.