### PR TITLE
Precomputed flag

### DIFF
--- a/src/config.jl
+++ b/src/config.jl
@@ -275,15 +275,16 @@ end
 
 Evaluate `g` at `x` using the precomputated values in `cfg`.
 Note that this is usually signifcant faster than `evaluate(g, x)`.
-With `precomputed=true` we rely on the previous intermediate results in `cfg`. Therefore
-the result is only correct if you previouls called `evaluate`, or `gradient` with the same
-`x`.
 
 ### Example
 ```julia
 cfg = GradientConfig(g)
 evaluate(g, x, cfg)
 ```
+
+With `precomputed=true` we rely on the previous intermediate results in `cfg`. Therefore
+the result is only correct if you previouls called `evaluate`, or `gradient` with the same
+`x`.
 """
 function evaluate(g::Polynomial, x::AbstractVector, cfg::GradientConfig{T}, precomputed=false) where T
     if !precomputed

--- a/test/config_test.jl
+++ b/test/config_test.jl
@@ -30,6 +30,19 @@
     @test [p(w) for p in ∇f] ≈ FixedPolynomials.gradient!(u, f, w, cfg)
     @test [p(w) for p in ∇f] ≈ u
 
+    cfg = GradientConfig(f)
+    @test f(w) ≈ evaluate(f, w, cfg)
+    @test [p(w) for p in ∇f] ≈ FixedPolynomials.gradient(f, w, cfg, true)
+
+    cfg = GradientConfig(f)
+    @test [p(w) for p in ∇f] ≈ FixedPolynomials.gradient(f, w, cfg)
+    @test f(w) ≈ evaluate(f, w, cfg, true)
+
+    cfg = GradientConfig(f)
+    u = zeros(3)
+    @test f(w) ≈ evaluate(f, w, cfg)
+    @test [p(w) for p in ∇f] ≈ FixedPolynomials.gradient!(u, f, w, cfg, true)
+
     cfg2 = deepcopy(cfg)
     @test cfg2 !== cfg
 
@@ -55,13 +68,21 @@
     @test [f(w), g(w)] ≈ evaluate!(u, [f, g], w, cfg)
     @test [f(w), g(w)] ≈ u
 
+    u = zeros(2)
+    cfg = JacobianConfig([f, g], w)
+    jacobian([f, g], w, cfg)
+    @test [f(w), g(w)] ≈ evaluate([f, g], w, cfg, true)
+    @test [f(w), g(w)] ≈ evaluate!(u, [f, g], w, cfg, true)
+    @test [f(w), g(w)] ≈ u
+
     cfg2 = deepcopy(cfg)
     @test cfg2 !== cfg
 
     U = zeros(2, 3)
     DF = vcat(RowVector([p(w) for p in ∇f]), [p(w) for p in ∇g] |> RowVector)
-    @test DF ≈ jacobian([f, g], w, cfg)
-    @test DF ≈ jacobian!(U, [f, g], w, cfg)
+    evaluate([f, g], w, cfg)
+    @test DF ≈ jacobian([f, g], w, cfg, true)
+    @test DF ≈ jacobian!(U, [f, g], w, cfg, true)
     @test DF ≈ U
 
     r = JacobianDiffResult(cfg)


### PR DESCRIPTION
This introduces a low level flag to avoid some computations.

Now you can do
```julia
cfg = GradientConfig(g)
evaluate(g, x, cfg)
gradient!(u, g, x, cfg, true)
```

This results in the same number of computations as
```
cfg = GradientConfig(g)
r = GradientDiffResult(cfg)
gradient!(r, g, x, cfg)
```

But is a little bit more flexible, e.g. for the case that you have a convergence check between evaluation and gradient.

