### PR TITLE
Fix pretty printing of polynomials (mostly)

### DIFF
--- a/src/show.jl
+++ b/src/show.jl
@@ -54,54 +54,17 @@ function print_poly(io::IO, p::Polynomial{T}, vars) where T
     end
 end
 
-function unicode_subscript(i)
-    if i == 0
-        "\u2080"
-    elseif i == 1
-        "\u2081"
-    elseif i == 2
-        "\u2082"
-    elseif i == 3
-        "\u2083"
-    elseif i == 4
-        "\u2084"
-    elseif i == 5
-        "\u2085"
-    elseif i == 6
-        "\u2086"
-    elseif i == 7
-        "\u2087"
-    elseif i == 8
-        "\u2088"
-    elseif i == 9
-        "\u2089"
-    end
-end
+# const SUBSCRIPT_TABLE = (0x2080, 0x2081, 0x2082, 0x2083, 0x2084, 0x2085, 0x2086, 0x2087, 0x2088, 0x2089)
+# const SUPERSCRIPT_TABLE = (0x2070, 0x00b9, 0x00b2, 0x00b3, 0x2074, 0x2075, 0x2076, 0x2077, 0x2078, 0x2079)
 
+const SUBSCRIPT_TABLE = ('\u2080', '\u2081', '\u2082', '\u2083', '\u2084', '\u2085', '\u2086', '\u2087', '\u2088', '\u2089')
+const SUPERSCRIPT_TABLE = ('\u2070', '\u00b9', '\u00b2', '\u00b3', '\u2074', '\u2075', '\u2076', '\u2077', '\u2078', '\u2079')
 
-function unicode_superscript(i)
-    if i == 0
-        "\u2070"
-    elseif i == 1
-        "\u00B9"
-    elseif i == 2
-        "\u00B2"
-    elseif i == 3
-        "\u00B3"
-    elseif i == 4
-        "\u2074"
-    elseif i == 5
-        "\u2075"
-    elseif i == 6
-        "\u2076"
-    elseif i == 7
-        "\u2077"
-    elseif i == 8
-        "\u2078"
-    elseif i == 9
-        "\u2079"
-    end
-end
+# const SUBSCRIPT_TABLE = ("₀","₁","₂","₃","₄","₅","₆","₇","₈","₉")
+# const SUPERSCRIPT_TABLE = ("⁰","¹","²","³","⁴","⁵","⁶","⁷","⁸","⁹")
+
+unicode_subscript(i::Int) = (SUBSCRIPT_TABLE[i + 1])
+unicode_superscript(i::Int) = (SUPERSCRIPT_TABLE[i + 1])
 
 pretty_power(pow::Int) = join(map(unicode_superscript, reverse(digits(pow))))
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,20 +1,6 @@
 import Base: print
 
-function Base.show(io::IO, p::Polynomial)
-    # if p.homogenized
-    #     vars = ["x$i" for i=0:nvariables(p)-1]
-    # else
-    #     vars = ["x$i" for i=1:nvariables(p)]
-    # end
-    print_poly(io, p, variables(p))
-end
-
-# function Base.show(io::IO, P::PolynomialSystem)
-#     for p in P.polys
-#         print_poly(io, p, P.vars)
-#         print(io, "\n")
-#     end
-# end
+Base.show(io::IO, p::Polynomial) = print_poly(io, p, variables(p))
 
 #helpers
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -1,10 +1,5 @@
-import Base: print
-
-Base.show(io::IO, p::Polynomial) = print_poly(io, p, variables(p))
-
-#helpers
-
-function print_poly(io::IO, p::Polynomial{T}, vars) where T
+function Base.show(io::IO, p::Polynomial{T}) where {T}
+    vars = variables(p)
     first = true
     exps = exponents(p)
     cfs = coefficients(p)
@@ -28,9 +23,9 @@ function print_poly(io::IO, p::Polynomial{T}, vars) where T
 
         for (var, power) in zip(vars, exp)
             if power == 1
-                print(io, "$(pretty_var(var))")
+                print(io, pretty_var(var))
             elseif power > 1
-                print(io, "$(pretty_var(var))$(pretty_power(power))")
+                print(io, pretty_var(var), pretty_power(power))
             end
         end
     end
@@ -40,29 +35,36 @@ function print_poly(io::IO, p::Polynomial{T}, vars) where T
     end
 end
 
-# const SUBSCRIPT_TABLE = (0x2080, 0x2081, 0x2082, 0x2083, 0x2084, 0x2085, 0x2086, 0x2087, 0x2088, 0x2089)
-# const SUPERSCRIPT_TABLE = (0x2070, 0x00b9, 0x00b2, 0x00b3, 0x2074, 0x2075, 0x2076, 0x2077, 0x2078, 0x2079)
-
 const SUBSCRIPT_TABLE = ('\u2080', '\u2081', '\u2082', '\u2083', '\u2084', '\u2085', '\u2086', '\u2087', '\u2088', '\u2089')
 const SUPERSCRIPT_TABLE = ('\u2070', '\u00b9', '\u00b2', '\u00b3', '\u2074', '\u2075', '\u2076', '\u2077', '\u2078', '\u2079')
-
-# const SUBSCRIPT_TABLE = ("₀","₁","₂","₃","₄","₅","₆","₇","₈","₉")
-# const SUPERSCRIPT_TABLE = ("⁰","¹","²","³","⁴","⁵","⁶","⁷","⁸","⁹")
 
 unicode_subscript(i::Int) = (SUBSCRIPT_TABLE[i + 1])
 unicode_superscript(i::Int) = (SUPERSCRIPT_TABLE[i + 1])
 
-pretty_power(pow::Int) = join(map(unicode_superscript, reverse(digits(pow))))
+function pretty_power(pow::Int)
+    io_out = IOBuffer()
+    _digits = digits(pow)
+    for i in _digits
+        print(io_out, unicode_superscript(i))
+    end
+    return reverse(String(take!(io_out)))
+end
 
 function pretty_var(var::String)
-    m = match(r"([a-zA-Z]+)(?:_*)(\d+)", var)
-    if m === nothing
-        var
-    else
-        base = string(m.captures[1])
-        index = parse(Int, m.captures[2])
-        base * join(map(unicode_subscript, reverse(digits(index))))
+    m1 = match(r"([a-zA-Z]+)(?:_*)(\d+)", var)
+    m2 = match(r"([a-zA-Z]+)(?:\[)(\d+)(?:\])", var)
+    if isnothing(m1) && isnothing(m2)
+        return var
     end
+    m = isnothing(m1) ? m2 : m1
+    io_out = IOBuffer()
+    print(io_out, m.captures[1])
+    index = parse(Int, m.captures[2])
+    _digits = reverse(digits(index))
+    for i in _digits
+        print(io_out, unicode_subscript(i))
+    end
+    return String(take!(io_out))
 end
 pretty_var(var) = pretty_var(string(var))
 


### PR DESCRIPTION
1. Made unicode super- and subscripts more compact

2. Performance considerations using `print(io, ...)` instead of `join`.

3. Code cleanup.  Merged the `print_poly` function directly into `Base.show`, as `print_poly` was only being used in the `show` definition (i.e., the function was redundant).

4. The `pretty_var` function was not printing correctly, causing tests to fail—the reason for this is because polynomials would sometimes print in the form
```julia
2z₂⁴
```
But sometimes of the form
```julia
2z[2]⁴
```
I'm not sure what caused that, nor for how long the tests were broken, but I just added an extra regex matching in the `pretty_var` function to capture this.  The only thing failing now is converting variables of `Polynomial` to `Symbol`s correctly:
```julia
poly: Test Failed at /home/jakewilliami/projects/FixedPolynomials.jl/test/poly_test.jl:41
  Expression: variables(F[1]) == [:z1, :z2]
   Evaluated: [Symbol("z[1]"), Symbol("z[2]")] == [:z1, :z2] 
# ...
Test Summary: | Pass  Fail  Total
poly          |   50     1     51
ERROR: LoadError: LoadError: Some tests did not pass: 50 passed, 1 failed, 0 errored, 0 broken.
```

Sorry I haven't been able to fix the `Symbol` problem.  It would be good to know what changes caused `Polynomial`s to print in 2 different ways.